### PR TITLE
Stabilize task-tracker Supabase sync and add SQL setup + docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,50 @@
+# Task Tracker Summary
+
+## Architecture (Current)
+
+- **Frontend:** `task-tracker/index.html`, `task-tracker/dashboard.html`, `task-tracker/styles.css`, `task-tracker/app.js`
+- **Hosting:** static site (GitHub Pages compatible)
+- **Auth:** Supabase Auth (email/password)
+- **Data:** Supabase Postgres (`profiles`, `tasks`)
+- **Access model:**
+  - `user` can only access own tasks
+  - `admin` can access all users and switch view in dashboard
+- **Data protection:** Row Level Security (RLS) policies in `task-tracker/supabase/schema.sql`
+
+## UX Status
+
+Implemented and preserved:
+- Glass + gradient interface with teal/amber/slate theme
+- Responsive day/week workflow
+- Toast feedback + skeleton loading states
+- Modal-based CRUD flow
+- Stats + summary cards
+
+## Cloud Sync Status
+
+Implemented:
+- Supabase client init from global config
+- Login/session checks via Supabase Auth
+- Profile fetch from `profiles`
+- Task CRUD via `tasks`
+- Admin user switching powered by `profiles`
+- Import/export on cloud-backed data
+- Legacy localStorage migration banner and migration flow
+
+Stabilization pass completed:
+- Guarded admin viewing-user fallback if selected user profile is missing
+- Safer select option binding for user switcher
+- Per-user error handling during legacy migration loop
+
+## Setup Artifacts Added
+
+- `task-tracker/supabase/schema.sql`
+  - creates `profiles` + `tasks`
+  - adds indexes
+  - adds `updated_at` trigger
+  - enables RLS + user/admin policies
+
+## Remaining TODOs
+
+- Manual end-to-end validation with a real Supabase project on both desktop + mobile
+- Optional polish pass after live-data QA (spacing/micro-interactions if needed)

--- a/task-tracker/README.md
+++ b/task-tracker/README.md
@@ -1,97 +1,106 @@
-# Task Tracker
+# Task Tracker (Supabase Cloud Sync)
 
-A simple and intuitive task tracking web application to help you manage your daily and weekly goals.
+Premium-looking daily/weekly task tracker with Supabase Auth + Postgres sync.
 
-## 🎯 Features
+## What this app supports
 
-- ✅ **Daily & Weekly Tasks** - Track both daily habits and weekly goals
-- 📊 **Progress Tracking** - Visual checkboxes for each day of the week
-- 👥 **Multi-User Support** - Separate task lists for different users
-- 🔐 **Simple Authentication** - Secure login system
-- 👨‍💼 **Admin Dashboard** - Master account to view and manage all users' tasks
-- 📱 **Responsive Design** - Works on desktop and mobile devices
-- 💾 **Local Storage** - All data saved in browser (no backend required)
-
-## 🔑 Login Credentials
-
-### Regular Users:
-- **Username:** `pradeep` | **Password:** `pradeep123`
-- **Username:** `sankar` | **Password:** `sankar123`
-
-### Admin/Master Account:
-- **Username:** `master` | **Password:** `master123`
-  - Can view and edit all users' tasks
-  - Switch between users using the dropdown
-
-## 🚀 How to Use
-
-### For Regular Users:
-1. Login with your credentials
-2. Click **"+ Add Task"** to create a new task
-3. Choose task type:
-   - **Daily**: For habits you want to do every day
-   - **Weekly Goal**: Set a target (e.g., "Apply to 5 companies this week")
-4. Use the **Day View** to focus on today's tasks
-5. Use the **Week View** to see your entire week at a glance
-6. Check off tasks as you complete them
-
-### For Admin (Master Account):
-1. Login as `master`
-2. Use the **"View User"** dropdown to switch between users
-3. View and edit any user's tasks
-4. Monitor progress across all users
-
-## 📦 Task Examples
-
-- **Daily Tasks:**
-  - Workout
-  - Run 1 mile
-  - Read for 30 minutes
-  - Meditate
-  
-- **Weekly Goals:**
-  - Apply to 5 companies (set target: 5)
-  - Reduce screen time to 14 hours/week
-  - Complete 3 project milestones
-
-## 🛠️ Technical Details
-
-- **Frontend Only** - Pure HTML, CSS, and JavaScript
-- **Storage** - Browser localStorage (data persists locally)
-- **No Backend Required** - Works offline after first load
-
-## 🌐 Access
-
-Visit: `https://pradeepjajjara.github.io/task-tracker/`
-
-## 📝 Future Enhancements (Backend Options)
-
-If you want to sync data across devices, consider these free backend options:
-
-1. **PythonAnywhere** (Free Tier)
-   - You're already using it for study-plan
-   - Can host Flask/Django APIs
-   - 1 web app free
-
-2. **Vercel/Netlify Functions**
-   - Serverless functions
-   - Free tier available
-   - Easy deployment
-
-3. **Firebase**
-   - Real-time database
-   - Authentication
-   - Free tier: 1GB storage
-
-4. **Supabase**
-   - PostgreSQL database
-   - RESTful API
-   - Free tier: 500MB storage
-
-## 📄 License
-
-Free to use and modify for personal purposes.
+- Day / Week task views
+- Task CRUD (add/edit/delete)
+- Daily and weekly completion tracking
+- Admin user switching (`View User` dropdown)
+- Cloud import/export backup tools
+- Legacy localStorage migration banner + one-click migration
+- Responsive UI (glass + gradient styling)
 
 ---
 
-**Made with ❤️ for productivity and accountability**
+## Prerequisites
+
+- A Supabase project
+- Browser access to Supabase SQL Editor and Authentication dashboard
+- GitHub Pages (or any static hosting)
+
+---
+
+## Setup order (exact sequence)
+
+1. **Create Supabase project**
+   - Supabase Dashboard → **New project**.
+
+2. **Create Auth users (email/password)**
+   - Dashboard → **Authentication** → **Users** → **Add user**.
+   - Create at least:
+     - one regular user (example: `pradeep@app.local`)
+     - one regular user (example: `sankar@app.local`)
+     - one admin user (example: `master@app.local`)
+
+3. **Run schema + RLS SQL**
+   - Dashboard → **SQL Editor** → **New query**.
+   - Paste and run: `task-tracker/supabase/schema.sql`.
+
+4. **Insert profile rows mapped to Auth user IDs**
+   - Dashboard → **Table Editor** → `auth.users` and copy each user `id`.
+   - Insert rows into `public.profiles` with matching `id` values:
+     - `username`: short handle used by app (example: `pradeep`)
+     - `display_name`: label for UI (example: `Pradeep`)
+     - `role`: `user` or `admin`
+
+   Example SQL (replace UUIDs):
+   ```sql
+   insert into public.profiles (id, username, display_name, role)
+   values
+     ('00000000-0000-0000-0000-000000000001', 'pradeep', 'Pradeep', 'user'),
+     ('00000000-0000-0000-0000-000000000002', 'sankar', 'Sankar', 'user'),
+     ('00000000-0000-0000-0000-000000000003', 'master', 'Master', 'admin')
+   on conflict (id) do update
+   set username = excluded.username,
+       display_name = excluded.display_name,
+       role = excluded.role;
+   ```
+
+5. **Get project API keys**
+   - Dashboard → **Project Settings** → **API**.
+   - Copy:
+     - Project URL
+     - anon public key
+
+6. **Configure frontend globals**
+   - Before `task-tracker/app.js` runs, define:
+   ```html
+   <script>
+     window.TASK_TRACKER_SUPABASE_URL = "https://YOUR_PROJECT.supabase.co";
+     window.TASK_TRACKER_SUPABASE_ANON_KEY = "YOUR_ANON_KEY";
+   </script>
+   ```
+   - Keep this script in `task-tracker/index.html` and `task-tracker/dashboard.html` (or shared include) before loading `app.js`.
+
+7. **Open app and sign in**
+   - Visit `/task-tracker/`
+   - Sign in using Auth email/password from step 2.
+
+---
+
+## Run / validation flow
+
+1. Sign in as regular user and verify only own tasks are visible.
+2. Add/edit/delete tasks, then refresh page to confirm cloud persistence.
+3. Sign in as admin and switch users using **View User**.
+4. Use export/import to validate backup path.
+5. If old browser keys exist (`tasks_<username>`), test migration banner action.
+
+---
+
+## Local developer checks
+
+- Syntax check:
+  ```bash
+  node --check task-tracker/app.js
+  ```
+
+---
+
+## Notes
+
+- This is a static frontend; the anon key is expected client-side.
+- RLS policies in `schema.sql` are what enforce data isolation.
+- Admin is determined by `profiles.role = 'admin'`.

--- a/task-tracker/app.js
+++ b/task-tracker/app.js
@@ -192,6 +192,9 @@ async function initializeDashboard() {
             masterControls.classList.remove("hidden");
         }
         await loadUserProfiles();
+        if (!userProfiles.some((profile) => profile.id === viewingUserId)) {
+            viewingUserId = currentProfile.id;
+        }
         populateViewUserOptions();
     }
 
@@ -272,7 +275,9 @@ function populateViewUserOptions() {
         select.appendChild(option);
     });
 
-    select.value = viewingUserId;
+    if (rows.some((profile) => profile.id === viewingUserId)) {
+        select.value = viewingUserId;
+    }
 }
 
 async function refreshDashboardData() {
@@ -1072,10 +1077,14 @@ async function migrateLegacyData(allUsers) {
             continue;
         }
 
-        const normalized = normalizeImportedTasks(tasks);
-        await replaceUserTasks(profile.id, normalized);
-        localStorage.setItem(`migrated_to_cloud_${username}`, "1");
-        migratedCount += 1;
+        try {
+            const normalized = normalizeImportedTasks(tasks);
+            await replaceUserTasks(profile.id, normalized);
+            localStorage.setItem(`migrated_to_cloud_${username}`, "1");
+            migratedCount += 1;
+        } catch (error) {
+            showToast(`Migration failed for ${username}: ${error.message || "unknown error"}`, "error");
+        }
     }
 
     await refreshDashboardData();

--- a/task-tracker/supabase/schema.sql
+++ b/task-tracker/supabase/schema.sql
@@ -1,0 +1,154 @@
+-- Task Tracker Supabase schema + RLS
+-- Run this in Supabase SQL Editor as project owner.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  username text not null unique,
+  display_name text not null,
+  role text not null default 'user' check (role in ('user','admin')),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null,
+  type text not null check (type in ('daily','weekly')),
+  description text not null default '',
+  target integer,
+  completions jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+-- Helpful indexes
+create index if not exists idx_tasks_user_id on public.tasks(user_id);
+create index if not exists idx_tasks_type on public.tasks(type);
+create index if not exists idx_tasks_created_at on public.tasks(created_at desc);
+create index if not exists idx_profiles_role on public.profiles(role);
+
+-- Keep updated_at fresh on update
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_tasks_set_updated_at on public.tasks;
+create trigger trg_tasks_set_updated_at
+before update on public.tasks
+for each row
+execute function public.set_updated_at();
+
+-- RLS
+alter table public.profiles enable row level security;
+alter table public.tasks enable row level security;
+
+-- Cleanup older policy versions for idempotent re-run
+DROP POLICY IF EXISTS "Profiles: read own" ON public.profiles;
+DROP POLICY IF EXISTS "Profiles: admin read all" ON public.profiles;
+DROP POLICY IF EXISTS "Tasks: read own" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: insert own" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: update own" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: delete own" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: admin read all" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: admin insert all" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: admin update all" ON public.tasks;
+DROP POLICY IF EXISTS "Tasks: admin delete all" ON public.tasks;
+
+-- Profiles policies
+create policy "Profiles: read own"
+on public.profiles
+for select
+using (auth.uid() = id);
+
+create policy "Profiles: admin read all"
+on public.profiles
+for select
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+-- Tasks policies: regular users can CRUD their own rows
+create policy "Tasks: read own"
+on public.tasks
+for select
+using (auth.uid() = user_id);
+
+create policy "Tasks: insert own"
+on public.tasks
+for insert
+with check (auth.uid() = user_id);
+
+create policy "Tasks: update own"
+on public.tasks
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "Tasks: delete own"
+on public.tasks
+for delete
+using (auth.uid() = user_id);
+
+-- Tasks policies: admins can CRUD all rows
+create policy "Tasks: admin read all"
+on public.tasks
+for select
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+create policy "Tasks: admin insert all"
+on public.tasks
+for insert
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+create policy "Tasks: admin update all"
+on public.tasks
+for update
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);
+
+create policy "Tasks: admin delete all"
+on public.tasks
+for delete
+using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  )
+);


### PR DESCRIPTION
### Motivation
- Finalize and stabilize the ongoing migration from a localStorage-only app to Supabase-backed auth and data so the existing premium UI/UX can run reliably with cloud sync.
- Provide a repeatable, idempotent SQL setup and clear onboarding docs so a developer can create the Supabase schema, map auth users to profiles, and run the app without guessing steps.

### Description
- Add `task-tracker/supabase/schema.sql` which creates `profiles` and `tasks` tables, helpful indexes, an `updated_at` trigger, and Row Level Security policies for `user` and `admin` access.
- Update `task-tracker/README.md` with an exact setup order for Supabase (create project; create Auth users; run `task-tracker/supabase/schema.sql`; insert `public.profiles` rows mapped to `auth.users.id`; copy project URL and anon key; set `window.TASK_TRACKER_SUPABASE_URL` and `window.TASK_TRACKER_SUPABASE_ANON_KEY`; open the app and sign in).
- Stabilize `task-tracker/app.js` by adding a fallback for `viewingUserId` when an admin-selected profile is missing, guarding the `viewUser` select assignment so only valid options are set, and adding per-user try/catch in the legacy-migration loop so one failed migration does not abort others.
- Added `SUMMARY.md` and committed the following files: `task-tracker/supabase/schema.sql` (new), `task-tracker/README.md` (updated), `task-tracker/app.js` (stabilized), and `SUMMARY.md` (new).

### Testing
- Ran a syntax check with `node --check task-tracker/app.js` which completed successfully without errors.
- Remaining automated/validation items: manual end-to-end testing with a real Supabase project on desktop and mobile is still required, and an optional UI polish pass after live-data QA remains as a TODO.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bfc81fea08331b01993f025fe54ac)